### PR TITLE
[SPC-91] feat: added nginx grpc_pass settings with ssl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     expose:
       - 1317 # rest
       - 26657 # rpc
+      - 9090 # gRPC
     ports:
       - 26656:26656 # p2p
-      - 9090:9090 # gRPC
     environment:
       - GAS_LIMIT=${GAS_LIMIT:-100000000}
       - STAKE_TOKEN=${STAKE_TOKEN:-ustake}
@@ -26,6 +26,7 @@ services:
     ports:
       - 1317:1317 # rest
       - 26657:26657 # rpc
+      - 9090:9090 # gRPC
     volumes:
       - ./nginx/config:/etc/nginx
       - /etc/letsencrypt:/etc/letsencrypt

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -4,7 +4,7 @@ http {
     '"$request" $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
   
-  server { # simple reverse-proxy
+  server { 
     listen [::]:1317 ssl;
     listen       1317 ssl;
     server_name  testnet.sourceprotocol.io;
@@ -27,6 +27,17 @@ http {
     add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
     location / {
       proxy_pass http://node:26657; #rpc
+    }
+  }
+  server { 
+    listen [::]:9090 ssl http2;
+    listen       9090 ssl http2;
+    server_name  testnet.sourceprotocol.io;
+    ssl_certificate     /etc/letsencrypt/live/testnet.sourceprotocol.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/testnet.sourceprotocol.io/privkey.pem;
+
+    location / {
+      grpc_pass      grpc://node:9090; # gRPC
     }
   }
 }


### PR DESCRIPTION
Added ssl to the grpc server, by modifying the nginx sidecar configuration. Used the grpc_pass nginx directive for this. Finally, the docker compose file was modified to expose the 9090 port from the nginx instead of the one from the main image. 

Tested the results with [grpcurl](https://github.com/fullstorydev/grpcurl), by running the following command: 

`grpcurl testnet.sourceprotocol.io:9090 list`

with the following observed results: 
![image](https://user-images.githubusercontent.com/74575331/172704213-c925690d-b25b-48b2-b5e7-4c87d27879ad.png)


Related article: https://www.nginx.com/blog/nginx-1-13-10-grpc/

Related task: *[SPC-91](https://thinkanddev.atlassian.net/browse/SPC-91)*: Add ssl to grpc on main node