### PR TITLE
[SPC-109] Fixed nginx config for wss

### DIFF
--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -26,6 +26,13 @@ http {
     add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
     location / {
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+
+      # WebSocket support
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
       proxy_pass http://node:26657; #rpc
     }
   }


### PR DESCRIPTION
Added correct handling of websocket over ssl on the nginx configuration.

Before this changes, websocket communication couldn't be established to the websocket on the node using the 26657 port (Where ssl is added). 
After the changes, wss (WS over SSL) communication to the 26657 port should work correctly. 
In order to test the functionality, an online tool to ping websockets can be used, like https://www.piesocket.com/websocket-tester, or a transfer can be done with the keplr wallet. 

Related task: *[SPC-109](https://thinkanddev.atlassian.net/browse/SPC-109)*: Bug fix websocket service on source node